### PR TITLE
Improve naming for sti-select relative functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Smart-Table-Improved is a collection of useful widgets for the great [Smart-Tabl
 
 - AngularJs
 - [Smart-Table]
+- Modern browsers (IE>=9 is required)
 
 ## Installation
 


### PR DESCRIPTION
Scope attributes change:
- `selected` -> `$stiSelected`
- `numSelected` -> `$stiNumSelected`

`sti-table` directive attribute changes:
- `track-selected` -> `track-selected-mode`
